### PR TITLE
feat: remove Jolly Holiday Lights

### DIFF
--- a/content/wordpress.md
+++ b/content/wordpress.md
@@ -20,7 +20,6 @@ plug-ins available to extend its functionality.
 
 These are some examples of past dsmHack projects which were built using WordPress:
 
-* [Jolly Holiday Lights](https://www.jollyholidaylights.org/) - (2019)
 * [Iowa Radio Reading](https://www.iowaradioreading.org/) - (2019)
 * [Community Support Advocates](https://teamcsa.org/) - (2019)
 * [RoofTop Foundation](http://rooftopfoundation.org/) - (2017)


### PR DESCRIPTION
Jolly Holiday Lights have redone their site this year and the link
here no longer reflects what was accomplished during the hack.